### PR TITLE
set windows CWD to wiki upon opening

### DIFF
--- a/autoload/mwiki/manage.vim
+++ b/autoload/mwiki/manage.vim
@@ -4,4 +4,5 @@
 function! mwiki#manage#GoToIndex(index)
     " echo mwikis - 1
     call mwiki#link#Enter(g:mwikis[a:index-1]['path']."index.md")
+    :lcd %:p:h "set windows current working directory to wiki - so that files save correctly if opening from outside the wiki folder
 endfunction


### PR DESCRIPTION
When opening via <LEADER>MW - from another folder - CWD remains the old folder - and files saved to the wiki are in the wrong directory.
This sets the CWD to the opened wiki's index file's location as the root. 
This I think is the sane default behavior.